### PR TITLE
Revert to Jira

### DIFF
--- a/change_request_form/views.py
+++ b/change_request_form/views.py
@@ -14,7 +14,7 @@ class ChangeRequestFormView(FormView):
     success_url = reverse_lazy('success')
 
     def form_valid(self, form):
-        self.request._ticket_id = form.create_zendesk_ticket()
+        self.request._ticket_id = form.create_jira_issue()
         return super().form_valid(form)
 
     def get_success_url(self):


### PR DESCRIPTION
Due to licensing issues we've decided to revert back to Jira.  I'm going to leave both integrations in place with required dependencies etc. so that we can revert the revert if needed.