### PR TITLE
Latest amends for the content team

### DIFF
--- a/change_request_form/forms.py
+++ b/change_request_form/forms.py
@@ -48,28 +48,28 @@ ZENDESK_REASON_TO_TAG_MAP = {
 
 class ChangeRequestForm(GOVUKForm):
     name = forms.CharField(
-        label='Your full name',
+        label='Your full name *',
         max_length=255,
         widget=widgets.TextInput(),
         required=True,
     )
 
     department = forms.CharField(
-        label='Policy team and directorate',
+        label='Policy team and directorate *',
         max_length=255,
         widget=widgets.TextInput(),
         required=True,
     )
 
     approver = forms.CharField(
-        label='Who has approved this request?',
+        label='Who has approved this request? *',
         max_length=255,
         widget=widgets.TextInput(),
         required=True,
     )
 
     email = forms.EmailField(
-        label='Your email address',
+        label='Your email address *',
         widget=widgets.TextInput(),
         required=True,
     )
@@ -82,7 +82,7 @@ class ChangeRequestForm(GOVUKForm):
     )
 
     action = forms.ChoiceField(
-        label='What do you want to do?',
+        label='What do you want to do? *',
         choices=REASON_CHOICES,
         widget=widgets.RadioSelect(),
         required=True,
@@ -96,16 +96,16 @@ class ChangeRequestForm(GOVUKForm):
     )
 
     title_of_request = forms.CharField(
-        label='Title of request',
+        label='Title of request *',
         required=True,
         max_length=100,
         widget=widgets.TextInput(),
     )
 
     description = forms.CharField(
-        label='Summary of your request',
+        label='Summary of your request *',
         widget=widgets.Textarea(),
-        required=False,
+        required=True,
     )
 
     due_date = fields.SplitDateField(
@@ -113,13 +113,6 @@ class ChangeRequestForm(GOVUKForm):
         required=False,
         min_year=dt.date.today().year,
         max_year=dt.date.today().year + 1,
-    )
-
-    time_due= forms.CharField(
-        label='Is there a specific time that your content needs to go live?',
-        required=False,
-        max_length=100,
-        widget=widgets.TextInput(),
     )
 
     date_explanation = forms.CharField(

--- a/change_request_form/forms.py
+++ b/change_request_form/forms.py
@@ -108,11 +108,11 @@ class ChangeRequestForm(GOVUKForm):
         required=True,
     )
 
-    due_date = fields.SplitDateField(
+    due_date = forms.CharField(
         label='Publication deadline (if applicable)',
         required=False,
-        min_year=dt.date.today().year,
-        max_year=dt.date.today().year + 1,
+        widget=widgets.TextInput(),
+        max_length=100,
     )
 
     date_explanation = forms.CharField(

--- a/change_request_form/forms.py
+++ b/change_request_form/forms.py
@@ -30,8 +30,6 @@ REASON_CHOICES = (
     ('Update or remove content on GOV.UK', 'Update or remove content on GOV.UK'),
     ('Add new content to great.gov.uk', 'Add new content to great.gov.uk'),
     ('Update or remove content on great.gov.uk', 'Update or remove content on great.gov.uk'),
-    ('Add new content to Digital Workspace', 'Add new content to Digital Workspace'),
-    ('Update or remove content on Digital Workspace', 'Update or remove content on Digital Workspace'),
 )
 
 REASON_TO_SERVICE_MAP = {
@@ -39,8 +37,6 @@ REASON_TO_SERVICE_MAP = {
     'Update or remove content on GOV.UK': 'GOV.UK',
     'Add new content to great.gov.uk': 'great.gov.uk',
     'Update or remove content on great.gov.uk': 'great.gov.uk',
-    'Add new content to Digital Workspace': 'Digital Workspace',
-    'Update or remove content on Digital Workspace': 'Digital Workspace',
 }
 
 ZENDESK_REASON_TO_TAG_MAP = {
@@ -48,8 +44,6 @@ ZENDESK_REASON_TO_TAG_MAP = {
     'Update or remove content on GOV.UK': '_GOV.UK',
     'Add new content to great.gov.uk': '_great.gov.uk',
     'Update or remove content on great.gov.uk': '_great.gov.uk',
-    'Add new content to Digital Workspace': 'Digital Workspace',
-    'Update or remove content on Digital Workspace': 'Digital Workspace',
 }
 
 
@@ -57,14 +51,16 @@ class ChangeRequestForm(GOVUKForm):
     name = forms.CharField(
         label='Your full name',
         max_length=255,
-        widget=widgets.TextInput()
+        widget=widgets.TextInput(),
+        required=True,
     )
 
     department = forms.CharField(
         label='Your directorate/section',
         max_length=255,
         widget=widgets.TextInput(),
-        help_text='Your content must have approval from your team leader before submitting for upload.'
+        help_text='Your content must have approval from your team leader before submitting for upload.',
+        required=True,
     )
 
     email = forms.EmailField(
@@ -86,12 +82,20 @@ class ChangeRequestForm(GOVUKForm):
         widget=widgets.RadioSelect(),
     )
 
+    update_url = forms.URLField(
+        label='Provide the URL of the page to be updated', max_length=255,
+        widget=widgets.TextInput(),
+        help_text='Only required for content updates',
+        required=False,
+    )
+
     description = forms.CharField(
         label='What is your content request? Please give as much detail as possible.',
         widget=widgets.Textarea(),
         help_text='Please outline your request, intended audience and its purpose '
                   '(for example, to sell, to inform, to explain). '
-                  'For updating/deleting existing content, please provide URL.'
+                  'For updating/deleting existing content, please provide URL.',
+        required=True,
     )
 
     due_date = fields.SplitDateField(
@@ -103,7 +107,7 @@ class ChangeRequestForm(GOVUKForm):
     )
 
     time_due= forms.CharField(
-        label='Time due',
+        label='Is there a specific time that your content needs to go live?',
         required=False,
         max_length=100,
         widget=widgets.TextInput(),
@@ -115,44 +119,18 @@ class ChangeRequestForm(GOVUKForm):
         required=False
     )
 
-    attachment1 = AVFileField(
-        label='Please attach the files containing the content you want to be uploaded',
-        max_length=255,
-        widget=widgets.ClearableFileInput(),
-        help_text='We accept Word documents with tracked changes - providing this will make the process very quick.',
-        required=False
+    title_of_request = forms.CharField(
+        label='Title of request',
+        required=True,
+        max_length=100,
+        widget=widgets.TextInput(),
     )
 
-    attachment2 = AVFileField(
-        label='',
-        max_length=255,
-        widget=widgets.ClearableFileInput(),
-        help_text='',
-        required=False
-    )
-
-    attachment3 = AVFileField(
-        label='',
-        max_length=255,
-        widget=widgets.ClearableFileInput(),
-        help_text='',
-        required=False
-    )
-
-    attachment4 = AVFileField(
-        label='',
-        max_length=255,
-        widget=widgets.ClearableFileInput(),
-        help_text='',
-        required=False
-    )
-
-    attachment5 = AVFileField(
-        label='',
-        max_length=255,
-        widget=widgets.ClearableFileInput(),
-        help_text='',
-        required=False
+    time_due= forms.CharField(
+        label='Is there a specific time that your content needs to go live?',
+        required=True,
+        max_length=100,
+        widget=widgets.TextInput(),
     )
 
     def clean_due_date(self):
@@ -160,6 +138,12 @@ class ChangeRequestForm(GOVUKForm):
         if date and date < dt.date.today():
             raise forms.ValidationError('The date cannot be in the past')
         return date
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if 'Update' in cleaned_data['action'] and not cleaned_data['update_url']:
+            raise forms.ValidationError('Provide an update url')
 
     def formatted_text(self):
         return ('Name: {name}\n'

--- a/change_request_form/forms.py
+++ b/change_request_form/forms.py
@@ -10,8 +10,6 @@ from govuk_forms.forms import GOVUKForm
 from govuk_forms import widgets, fields
 import requests
 
-from .fields import AVFileField
-
 
 def slack_notify(message):
     slack_message = json.dumps(
@@ -30,6 +28,7 @@ REASON_CHOICES = (
     ('Update or remove content on GOV.UK', 'Update or remove content on GOV.UK'),
     ('Add new content to great.gov.uk', 'Add new content to great.gov.uk'),
     ('Update or remove content on great.gov.uk', 'Update or remove content on great.gov.uk'),
+    ('Ask a question', 'Ask a question'),
 )
 
 REASON_TO_SERVICE_MAP = {
@@ -56,30 +55,37 @@ class ChangeRequestForm(GOVUKForm):
     )
 
     department = forms.CharField(
-        label='Your directorate/section',
+        label='Policy team and directorate',
         max_length=255,
         widget=widgets.TextInput(),
-        help_text='Your content must have approval from your team leader before submitting for upload.',
+        required=True,
+    )
+
+    approver = forms.CharField(
+        label='Who has approved this request?',
+        max_length=255,
+        widget=widgets.TextInput(),
         required=True,
     )
 
     email = forms.EmailField(
         label='Your email address',
-        widget=widgets.TextInput()
+        widget=widgets.TextInput(),
+        required=True,
     )
 
     telephone = forms.CharField(
         label='Phone number',
         max_length=255,
         widget=widgets.TextInput(),
-        help_text='Please provide a direct number in case we need to discuss your request.'
+        required=False,
     )
 
     action = forms.ChoiceField(
-        label='Do you want to add, update or remove content?',
+        label='What do you want to do?',
         choices=REASON_CHOICES,
-        help_text='Please allow a minimum of 3 working days to allow for feedback, approval and upload.',
         widget=widgets.RadioSelect(),
+        required=True,
     )
 
     update_url = forms.URLField(
@@ -89,19 +95,22 @@ class ChangeRequestForm(GOVUKForm):
         required=False,
     )
 
-    description = forms.CharField(
-        label='What is your content request? Please give as much detail as possible.',
-        widget=widgets.Textarea(),
-        help_text='Please outline your request, intended audience and its purpose '
-                  '(for example, to sell, to inform, to explain). '
-                  'For updating/deleting existing content, please provide URL.',
+    title_of_request = forms.CharField(
+        label='Title of request',
         required=True,
+        max_length=100,
+        widget=widgets.TextInput(),
+    )
+
+    description = forms.CharField(
+        label='Summary of your request',
+        widget=widgets.Textarea(),
+        required=False,
     )
 
     due_date = fields.SplitDateField(
-        label='Do you have a publication deadline?',
-        help_text='If so, give date and reason.',
-        required=True,
+        label='Publication deadline (if applicable)',
+        required=False,
         min_year=dt.date.today().year,
         max_year=dt.date.today().year + 1,
     )
@@ -114,23 +123,9 @@ class ChangeRequestForm(GOVUKForm):
     )
 
     date_explanation = forms.CharField(
-        label='Reason',
+        label='Reason for deadline',
         widget=widgets.TextInput(),
         required=False
-    )
-
-    title_of_request = forms.CharField(
-        label='Title of request',
-        required=True,
-        max_length=100,
-        widget=widgets.TextInput(),
-    )
-
-    time_due= forms.CharField(
-        label='Is there a specific time that your content needs to go live?',
-        required=True,
-        max_length=100,
-        widget=widgets.TextInput(),
     )
 
     def clean_due_date(self):

--- a/change_request_form/templates/change_request.html
+++ b/change_request_form/templates/change_request.html
@@ -3,7 +3,7 @@
 {% block inner_content %}
 <h1 class="heading-large">Request a content update</h1>
 <p>All requests to upload new or change existing content must be raised through this form. Please provide one request at
-    a time and as much detail as you can. You can upload your content at the bottom of the form.</p>
+    a time and as much detail as you can.</p>
 <form method="post" action="{{ request.path }}" enctype="multipart/form-data">
 
     {% if form.non_field_errors %}

--- a/change_request_form/templates/change_request.html
+++ b/change_request_form/templates/change_request.html
@@ -1,11 +1,22 @@
 {% extends 'govuk_template.html' %}
 
 {% block inner_content %}
-    <h1 class="heading-large">Request a content update</h1>
-    <p>All requests to upload new or change existing content must be raised through this form. Please provide one request at a time and as much detail as you can. You can upload your content at the bottom of the form.</p>
-    <form method="post" action="{{ request.path }}" enctype="multipart/form-data">
-        {% csrf_token %}
-        {{ form }}
-        <input type="submit" class="button" value="Submit request" />
-    </form>
+<h1 class="heading-large">Request a content update</h1>
+<p>All requests to upload new or change existing content must be raised through this form. Please provide one request at
+    a time and as much detail as you can. You can upload your content at the bottom of the form.</p>
+<form method="post" action="{{ request.path }}" enctype="multipart/form-data">
+
+    {% if form.non_field_errors %}
+    <div class="error-summary">
+        <h2 class="error-summary-heading heading-medium">Form errors</h2>
+        <ul class="errorlist error-summary-list">
+            <li><a href="#id_update_url-label">Provide the URL of the page to be updated</a></li>
+        </ul>
+    </div>
+    {% endif %}
+
+    {% csrf_token %}
+    {{ form }}
+    <input type="submit" class="button" value="Submit request"/>
+</form>
 {% endblock %}


### PR DESCRIPTION
remove option for customers to add attachments
remove Digital Workspace (they use their own system)
make the following four fields manadatory - name; policy team and directorate; type of request; what is your request
Amend 'time due' to Is there a specific time that your content needs to go live?'
Where content request is for an update, add a mandatory field asking for the URL of the page to be updated
Add a mandatory field for 'title of request'
Add the mandatory question 'Who will fact check the final version of the content?'